### PR TITLE
Add column stagger

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,6 +30,11 @@ Dist.Lateral = 1.4 # Lateral movement multiplier
 # Can be overriden using the -stagger flag.
 Stagger = false
 
+# Set to true to measure distances with set column staggers.
+# Can be overriden using the -colstagger flag.
+ColStagger = false
+ColStaggers = [0, 0.75, 1.25, 0.80, 0.75, 0.75, 0.80, 1.25, 0.75, 0]
+
 [Weights.Fspeed]
 SFB = 1.0 # Weight of sfbs
 DSFB = 0.5 # Weight of dsfbs

--- a/config.toml
+++ b/config.toml
@@ -33,6 +33,7 @@ Stagger = false
 # Set to true to measure distances with set column staggers.
 # Can be overriden using the -colstagger flag.
 ColStagger = false
+# For columns after the 10th, last stagger value is used.
 ColStaggers = [0, 0.75, 1.25, 0.80, 0.75, 0.75, 0.80, 1.25, 0.75, 0]
 
 [Weights.Fspeed]

--- a/globals.go
+++ b/globals.go
@@ -15,6 +15,8 @@
 package main
 
 var StaggerFlag bool
+var ColStaggerFlag bool
+var ColStaggers [10]float64
 var SlideFlag bool
 var DynamicFlag bool
 var ImproveFlag bool
@@ -54,6 +56,8 @@ var Config struct {
 	}
 	Weights struct {
 		Stagger bool
+		ColStagger bool
+		ColStaggers [10]float64
 		FSpeed  struct {
 			SFB       float64
 			DSFB      float64

--- a/layout.go
+++ b/layout.go
@@ -760,9 +760,21 @@ func staggeredX(c, r int) float64 {
 	return sx
 }
 
+func staggeredY(c, r int) float64 {
+	var sy float64
+	if c < 10 {
+		sy = float64(r) - Config.Weights.ColStaggers[c]
+	} else if c >= 10 {
+		sy = float64(r) - Config.Weights.ColStaggers[9]//Unsure if pinky stagger being the same is guaranteed
+	}
+	return sy
+}
+
 func twoKeyDist(a, b Pos, weighted bool) float64 {
 	var ax float64
 	var bx float64
+	var ay float64
+	var by float64
 
 	if StaggerFlag {
 		ax = staggeredX(a.Col, a.Row)
@@ -772,8 +784,16 @@ func twoKeyDist(a, b Pos, weighted bool) float64 {
 		bx = float64(b.Col)
 	}
 
+	if ColStaggerFlag {
+		ay = staggeredY(a.Col, a.Row)
+		by = staggeredY(b.Col, b.Row)
+	} else {
+		ay = float64(a.Row)
+		by = float64(b.Row)
+	}
+	
 	x := ax - bx
-	y := float64(a.Row - b.Row)
+	y := ay - by
 
 	var dist float64
 	if weighted {

--- a/main.go
+++ b/main.go
@@ -333,6 +333,7 @@ func commandUsage(command *Command) {
 func main() {
 	ReadWeights()
 	flag.BoolVar(&StaggerFlag, "stagger", Config.Weights.Stagger, "if true, calculates distance for ANSI row-stagger form factor")
+	flag.BoolVar(&ColStaggerFlag, "colstagger", Config.Weights.ColStagger, "if true, calculates distance for col-stagger form factor")
 	flag.BoolVar(&SlideFlag, "slide", false, "if true, ignores slideable sfbs (made for Oats) (might not work)")
 	flag.BoolVar(&DynamicFlag, "dynamic", false, "")
 	flag.Parse()


### PR DESCRIPTION
Introduces a user-set column stagger feature.

`config.toml` should probably be proofread for a better explanation and `layout.go` should be checked to confirm the logic is correct.

If you want the `ColStaggers` to be more mild like the keymui you should change the preset to `[0, 0.2, 0.25, 0.15, 0.10, 0.10, 0.15, 0.25, 0.2, 0]` since the current preset is from my sweep keyboard file for keymui.